### PR TITLE
feat: pre-launch operational readiness — MinIO, security headers, rate limiting, GDPR, cron sync

### DIFF
--- a/.claude/plans/issues-batch-may2026.md
+++ b/.claude/plans/issues-batch-may2026.md
@@ -1,0 +1,60 @@
+## Goal
+Execute all actionable GitHub issues before public launch of alteko.lv.
+
+## Context
+Issues #122, #129, #139, #152, #153, #154 are open. Most are infrastructure/operational readiness.
+Working in worktree feat/issues-batch-may2026.
+
+## Steps
+
+### Step 1: Docker/Infrastructure (#152 + #154 item 1)
+- [ ] docker-compose.yml: Add HOSTNAME=0.0.0.0 to app service env
+- [ ] docker-compose.yml: Add minio service (internal port 127.0.0.1:3021:9000)
+- [ ] docker-compose.yml: Add minio-init one-shot job (mc mb buckets)
+- [ ] deploy.yml: Add S3_* defaults pointing to minio:9000 in .env generation
+- [ ] .env.example: Update production S3 comments to reflect MinIO-on-VPS approach
+- [ ] docs/technical/adr/0001-s3-provider.md: Status → Superseded by ADR-0002
+- [ ] docs/technical/adr/0002-s3-provider-revised.md: Create ADR
+- [ ] docs/DEPLOY.md: Add MinIO provisioning section
+
+### Step 2: Security headers (#154 item 7)
+- [ ] next.config.mjs: Add headers() with X-Frame-Options, X-Content-Type-Options,
+      Referrer-Policy, Permissions-Policy
+
+### Step 3: Rate limiting (#154 item 8)
+- [ ] src/lib/rate-limit.ts: Simple in-memory token bucket (no external deps)
+- [ ] Apply to /api/audit/*, /api/buildings/*, /api/address/* routes via middleware
+
+### Step 4: Cookie consent (#154 item 5)
+- [ ] src/components/cookie-consent.tsx: Lightweight banner component
+- [ ] src/app/layout.tsx (or [locale]/layout): Add CookieConsent component
+
+### Step 5: Sync cron (#154 item 4)
+- [ ] .github/workflows/sync-data.yml: Add cron schedule + SSH-based execution
+      (appleboy/ssh-action to run docker compose exec app npx tsx scripts/...)
+
+### Step 6: E2E smoke test (#154 item 12)
+- [ ] .github/workflows/deploy.yml: Add smoke-test step after health probe
+      (curl checks for key public pages)
+
+### Step 7: Code quality (#154 item 11)
+- [ ] package.json: Add engines: { node: ">=22 <23", npm: ">=10 <12" }
+
+### Step 8: Sentry (#154 item 6)
+- [ ] npm install @sentry/nextjs
+- [ ] Create sentry.client.config.ts, sentry.server.config.ts, sentry.edge.config.ts
+- [ ] Create instrumentation.ts with Sentry.init (no-op if SENTRY_DSN is not set)
+- [ ] Add SENTRY_DSN to .env.example + deploy.yml
+
+## Risks
+- MinIO on VPS: +~256 MB RAM. VPS has 4 GB, total ~2-2.5 GB after all services. Acceptable.
+- Sentry: new package. Keep graceful: disabled if SENTRY_DSN is absent.
+- Rate limiting: in-memory, lost on restart. Acceptable for single-container deploy.
+- Cookie consent: must not block page load (async). No analytics injected yet.
+
+## Not in scope (human action required)
+- #122 SIA registration
+- #153 real API keys (OPENAI, Resend)
+- #139 Resend domain verify + DKIM/DMARC DNS
+- #154 item 3 off-site DB backup (Backblaze B2 setup)
+- #154 items 9,10 GSC + DKIM

--- a/.env.example
+++ b/.env.example
@@ -52,12 +52,16 @@ S3_REGION="us-east-1"
 S3_BUCKET="alteko-local"
 S3_ACCESS_KEY_ID="minioadmin"
 S3_SECRET_ACCESS_KEY="minioadmin"
-# Production: replace with real S3/Cloudflare R2/Hetzner Object Storage
-# S3_ENDPOINT="https://s3.eu-central-1.amazonaws.com"
-# S3_REGION="eu-central-1"
-# S3_BUCKET="alteko-prod"
-# S3_ACCESS_KEY_ID="AKIA..."
-# S3_SECRET_ACCESS_KEY="..."
+# Production: MinIO runs on the Hetzner Volume via docker-compose.
+# App connects over the internal Docker network.
+# S3_ENDPOINT="http://minio:9000"
+# S3_REGION="us-east-1"
+# S3_BUCKET="alteko-uploads"
+# S3_ACCESS_KEY_ID="<generate: openssl rand -hex 16>"
+# S3_SECRET_ACCESS_KEY="<generate: openssl rand -hex 32>"
+# MinIO root credentials — must match S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY:
+# MINIO_ROOT_USER="<same as S3_ACCESS_KEY_ID>"
+# MINIO_ROOT_PASSWORD="<same as S3_SECRET_ACCESS_KEY>"
 
 # External APIs
 # Note: Jāņa sēta commercial geocoder was evaluated and dropped — too expensive
@@ -96,3 +100,6 @@ KEEP_TEMP_FILES="false"
 # Should be a separate secret from NEXTAUTH_SECRET in production so they can be
 # rotated independently. In CI/CD, may temporarily fall back to NEXTAUTH_SECRET.
 PAYLOAD_SECRET="change-me-min-32-chars-random-string"
+
+# Sentry error tracking (optional — disabled if blank)
+SENTRY_DSN=""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
           LVM_GEOSERVER_URL: ${{ secrets.LVM_GEOSERVER_URL }}
           S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
@@ -90,7 +91,7 @@ jobs:
           host: ${{ secrets.HETZNER_HOST }}
           username: ${{ secrets.HETZNER_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
-          envs: IMAGE_TAG,GITHUB_REPOSITORY,POSTGRES_PASSWORD,NEXTAUTH_SECRET,OPENAI_API_KEY,RESEND_API_KEY,ADMIN_EMAIL,PAYLOAD_SECRET,LVM_GEOSERVER_URL,S3_ENDPOINT,S3_REGION,S3_BUCKET,S3_ACCESS_KEY_ID,S3_SECRET_ACCESS_KEY,GHCR_TOKEN
+          envs: IMAGE_TAG,GITHUB_REPOSITORY,POSTGRES_PASSWORD,NEXTAUTH_SECRET,OPENAI_API_KEY,RESEND_API_KEY,ADMIN_EMAIL,PAYLOAD_SECRET,LVM_GEOSERVER_URL,S3_ENDPOINT,S3_REGION,S3_BUCKET,S3_ACCESS_KEY_ID,S3_SECRET_ACCESS_KEY,GHCR_TOKEN,SENTRY_DSN
           command_timeout: 20m
           script: |
             set -euo pipefail
@@ -136,6 +137,9 @@ jobs:
             S3_BUCKET=${S3_BUCKET}
             S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
             S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+            MINIO_ROOT_USER=${S3_ACCESS_KEY_ID}
+            MINIO_ROOT_PASSWORD=${S3_SECRET_ACCESS_KEY}
+            SENTRY_DSN=${SENTRY_DSN:-}
 
             APP_VERSION=${IMAGE_TAG}
             IMAGE_TAG=${IMAGE_TAG}
@@ -159,6 +163,9 @@ jobs:
             else
               echo "DB not running yet — skipping pre-deploy backup (first deploy)"
             fi
+
+            # ── Ensure MinIO data directory exists (first-deploy setup) ──
+            mkdir -p /mnt/data/alteko/minio
 
             # ── Pull and restart ──────────────────────────────────────────
             docker compose pull app
@@ -188,3 +195,18 @@ jobs:
             # ── Cleanup ───────────────────────────────────────────────────
             docker image prune -f
             echo "Deployed ALTEKO ${IMAGE_TAG}"
+
+            # ── Smoke tests — verify key public pages return 200 ─────────────────
+            echo "Running smoke tests..."
+            smoke_ok=1
+            for path in "/" "/ru" "/api/health" "/sitemap.xml" "/robots.txt"; do
+              if ! curl -fsS --max-time 10 "https://alteko.lv${path}" > /dev/null 2>&1; then
+                echo "SMOKE FAIL: https://alteko.lv${path} did not return 200"
+                smoke_ok=0
+              fi
+            done
+            if [ "${smoke_ok}" = "0" ]; then
+              echo "===== SOME SMOKE TESTS FAILED — manual verification recommended ====="
+            else
+              echo "All smoke tests passed."
+            fi

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -3,20 +3,19 @@ name: Sync Open Data
 # Syncs Latvian government open datasets into PostgreSQL.
 # All sources are CC-BY-4.0 and free to bulk-download from data.gov.lv.
 #
-# CURRENTLY MANUAL ONLY (workflow_dispatch). The cron schedule was disabled
-# because the production Postgres lives on the internal Docker network at
-# /opt/alteko and is not reachable from GitHub-hosted runners. Re-enabling
-# scheduled syncs requires either (a) exposing prod DB on a non-default port
-# with strong creds, or (b) refactoring this workflow to SSH into the server
-# and run the script inside the running app container. See follow-up TODO.
+# Scheduled syncs run via SSH into the VPS and execute scripts inside the
+# running app container (the DB is on the internal Docker network, not
+# reachable directly from GitHub-hosted runners).
 #
-# Workflow_dispatch still runs the scripts against whatever DATABASE_URL
-# secret is set — useful for local one-offs against a tunnel.
-#
-# TODO(infra): re-enable scheduled syncs by running scripts on the server
-# via appleboy/ssh-action and `docker compose exec app npx tsx scripts/...`.
+# Manual one-off runs (workflow_dispatch) still work against whatever
+# DATABASE_URL secret is set — useful for local development against a tunnel.
 on:
   workflow_dispatch:
+  schedule:
+    # Weekly on Sunday at 03:00 UTC — buildings, addresses, energy certificates
+    - cron: '0 3 * * 0'
+    # Monthly on the 1st at 04:00 UTC — apartment transaction prices
+    - cron: '0 4 1 * *'
     inputs:
       job:
         description: 'Which sync job to run'
@@ -100,3 +99,43 @@ jobs:
 
       - name: Sync apartment transactions
         run: npx tsx scripts/sync-transactions.ts
+
+  # ── Scheduled sync via SSH (cron-triggered only) ──────────────────────────
+  weekly-sync-ssh:
+    name: Weekly SSH — buildings, addresses, energy certs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' && github.event.schedule == '0 3 * * 0'
+
+    steps:
+      - uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: ${{ secrets.HETZNER_USER }}
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          command_timeout: 30m
+          script: |
+            set -euo pipefail
+            cd /opt/alteko
+            echo "Starting weekly data sync inside app container..."
+            docker compose exec -T app npx tsx scripts/sync-vzd.ts
+            docker compose exec -T app npx tsx scripts/sync-bvkb.ts
+            echo "Weekly sync complete."
+
+  monthly-transactions-ssh:
+    name: Monthly SSH — apartment transactions
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' && github.event.schedule == '0 4 1 * *'
+
+    steps:
+      - uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: ${{ secrets.HETZNER_USER }}
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          command_timeout: 60m
+          script: |
+            set -euo pipefail
+            cd /opt/alteko
+            echo "Starting monthly transactions sync inside app container..."
+            docker compose exec -T app npx tsx scripts/sync-transactions.ts
+            echo "Monthly transactions sync complete."

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -11,11 +11,6 @@ name: Sync Open Data
 # DATABASE_URL secret is set — useful for local development against a tunnel.
 on:
   workflow_dispatch:
-  schedule:
-    # Weekly on Sunday at 03:00 UTC — buildings, addresses, energy certificates
-    - cron: '0 3 * * 0'
-    # Monthly on the 1st at 04:00 UTC — apartment transaction prices
-    - cron: '0 4 1 * *'
     inputs:
       job:
         description: 'Which sync job to run'
@@ -27,6 +22,11 @@ on:
           - buildings
           - addresses
           - energy-certs
+  schedule:
+    # Weekly on Sunday at 03:00 UTC — buildings, addresses, energy certificates
+    - cron: '0 3 * * 0'
+    # Monthly on the 1st at 04:00 UTC — apartment transaction prices
+    - cron: '0 4 1 * *'
 
 jobs:
   weekly-sync:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,16 @@ services:
     ports:
       - "127.0.0.1:3020:3000"
     env_file: .env
+    environment:
+      # Next.js standalone server defaults to binding on localhost (127.0.0.1),
+      # which inside the container resolves to ::1 (IPv6). Docker's wget-based
+      # healthcheck connects via IPv4, so it hits "Connection refused".
+      # Binding on 0.0.0.0 makes the server accept connections on all interfaces.
+      HOSTNAME: "0.0.0.0"
     depends_on:
       db:
+        condition: service_healthy
+      minio:
         condition: service_healthy
     # Migrations run on every start — prisma migrate deploy is idempotent.
     entrypoint: ["/docker-entrypoint.sh"]
@@ -64,3 +72,38 @@ services:
       retries: 5
     mem_limit: 512m
     cpus: 0.5
+
+  minio:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    ports:
+      # Internal only — no public console exposure.
+      # Access console via SSH tunnel: ssh -L 9001:localhost:9001 palpalych
+      - "127.0.0.1:3021:9000"
+    env_file: .env
+    volumes:
+      # Hetzner Volume bind — Ceph-backed, survives docker prune and server rebuild.
+      - /mnt/data/alteko/minio:/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    mem_limit: 256m
+    cpus: 0.5
+
+  minio-init:
+    image: minio/mc:RELEASE.2024-11-09T19-22-20Z
+    restart: on-failure
+    depends_on:
+      minio:
+        condition: service_healthy
+    env_file: .env
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD &&
+        mc mb --ignore-existing local/alteko-documents local/alteko-uploads local/alteko-reports local/alteko-media

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -27,6 +27,7 @@ GitHub Actions (.github/workflows/deploy.yml)
 Hetzner VPS  /opt/alteko/
     ├── app (Docker, Next.js + Payload)  — port 3020 на хосте → 3000 в контейнере
     ├── db (Docker, postgres:16-alpine) — данные в /mnt/data/alteko/postgres
+    ├── minio  (MinIO S3, internal) — port 3021 на хосте → 9000 в контейнере
     └── nginx (host)                     — reverse proxy, HTTPS via Certbot
 ```
 
@@ -57,6 +58,7 @@ Container entrypoint (`scripts/docker-entrypoint.sh`) при каждом ста
 | `/mnt/data/alteko/postgres` | PostgreSQL data (Hetzner Volume — переживает rebuild сервера) |
 | `/mnt/data/alteko/uploads` | Payload media (если самохост; иначе S3) |
 | `/mnt/data/alteko/backups` | `pg_dump` дампы перед каждым deploy (последние 10, gzip) |
+| `/mnt/data/alteko/minio` | MinIO object storage (S3-совместимый) |
 
 ### Port allocation на VPS
 
@@ -64,6 +66,7 @@ Container entrypoint (`scripts/docker-entrypoint.sh`) при каждом ста
 |------|--------|
 | 3010 | MezaData |
 | 3020 | **ALTEKO** |
+| 3021 | ALTEKO MinIO (внутренний, SSH-tunnel) |
 | 3030+ | будущие проекты |
 
 ### nginx vhost
@@ -92,10 +95,12 @@ Container entrypoint (`scripts/docker-entrypoint.sh`) при каждом ста
 | `RESEND_API_KEY` | ключ Resend (домен alteko.lv должен быть verified — см. issue #139) |
 | `ADMIN_EMAIL` | куда падают уведомления о новых заявках |
 | `LVM_GEOSERVER_URL` | WFS endpoint LVM (cadastral lookup, бесплатный) |
-| `S3_ENDPOINT` | Hetzner Object Storage endpoint, например `https://fsn1.your-objectstorage.com` (Falkenstein) или `https://hel1.your-objectstorage.com` (Helsinki). См. ADR `docs/technical/adr/0001-s3-provider.md` |
-| `S3_REGION` | `fsn1` или `hel1` |
-| `S3_BUCKET` | имя bucket, по умолчанию `alteko-uploads`. Для документов и медиа используются отдельные bucket'ы (см. ADR) |
-| `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` | ключи Hetzner Object Storage |
+| `S3_ENDPOINT` | `http://minio:9000` (MinIO внутри docker-compose) |
+| `S3_REGION` | `us-east-1` (MinIO требует непустое значение; фактически не используется) |
+| `S3_BUCKET` | `alteko-uploads` (основной bucket; остальные создаются через `minio-init`) |
+| `S3_ACCESS_KEY_ID` | MinIO root credentials (генерировать: `openssl rand -hex 16`) |
+| `S3_SECRET_ACCESS_KEY` | MinIO root credentials (генерировать: `openssl rand -hex 32`) |
+| `SENTRY_DSN` | DSN Sentry (опционально; если не задан — мониторинг отключён) |
 
 `DATABASE_URL` **не** secret — он собирается в deploy-скрипте:
 ```

--- a/docs/technical/adr/0001-s3-provider.md
+++ b/docs/technical/adr/0001-s3-provider.md
@@ -3,7 +3,7 @@
 | | |
 |---|---|
 | Дата | 2026-05-09 |
-| Статус | **Принято** |
+| Статус | **Superseded by ADR-0002** (2026-05-11) |
 | Автор | ALTEKO team |
 | Связанные | #139 (provisioning), #147 (pre-flight), `docs/technical/architecture.md` |
 

--- a/docs/technical/adr/0002-s3-provider-revised.md
+++ b/docs/technical/adr/0002-s3-provider-revised.md
@@ -1,0 +1,81 @@
+# ADR 0002 — MinIO на Hetzner Volume как production S3 backend
+
+| | |
+|---|---|
+| Дата | 2026-05-11 |
+| Статус | **Принято** (supersedes ADR-0001) |
+| Автор | ALTEKO team |
+| Связанные | #152 (issue), ADR-0001 (superseded), `docs/DEPLOY.md` |
+
+---
+
+## Контекст
+
+ADR-0001 выбрал Hetzner Object Storage, аргументируя надёжностью хранения. Этот аргумент оказался ошибочным: **Hetzner Volume — сетевое блочное хранилище на Ceph-кластере** с встроенной репликацией, а не один физический диск.
+
+Дополнительно: статус Hetzner Object Storage API в регионах Falkenstein/Helsinki не был подтверждён на момент принятия ADR-0001.
+
+---
+
+## Решение
+
+Использовать **MinIO single-node** на существующем Hetzner Volume (`/mnt/data/alteko/minio`).
+
+### Архитектура
+
+```
+Hetzner VPS (89.167.4.195)
+/mnt/data/alteko/minio/  ← данные на Hetzner Volume (Ceph)
+
+docker-compose.yml:
+  app         → http://minio:9000 (внутренняя docker-сеть)
+  db          (postgres)
+  minio       → /mnt/data/alteko/minio, port 127.0.0.1:3021:9000
+  minio-init  (one-shot: создаёт buckets при первом старте)
+```
+
+### Buckets
+
+| Bucket | Содержимое | Срок хранения |
+|--------|-----------|---------------|
+| `alteko-documents` | Документы дома (энергосертификат, протоколы) | бессрочно |
+| `alteko-uploads` | PDF-счета пользователей | 90 дней после анализа |
+| `alteko-reports` | Readiness Report PDF | 365 дней |
+| `alteko-media` | Payload CMS media | бессрочно |
+
+---
+
+## Tradeoffs
+
+| Критерий | MinIO на Volume | Hetzner Object Storage |
+|---|---|---|
+| Стоимость/мес | €0 (Volume оплачен) | ~€0.60 @ 100 GB |
+| Durability | Ceph (~6×9) | 11×9 |
+| RAM | +256 MB из 4 GB | 0 |
+| Latency | <1 ms (docker-сеть) | ~2-5 ms |
+| DR | detach/reattach Volume | managed |
+| Vendor lock-in | нет (S3 API) | нет (S3 API) |
+
+---
+
+## DR-стратегия
+
+Hetzner Volume защищает от disk failure (Ceph). Для off-site backup: cron rclone sync → Backblaze B2 (~€0.50/мес при 100 GB). Это отдельный follow-up issue (#154 item 3).
+
+---
+
+## Ограничения
+
+- MinIO консоль недоступна публично — только через SSH-tunnel на порт 3021
+- При падении VPS файлы недоступны до восстановления контейнера (данные сохраняются на Volume)
+- Single-node MinIO без HA — acceptable для данного объёма и стадии
+
+---
+
+## Acceptance criteria
+
+- [x] ADR-0001 помечен как Superseded
+- [x] `minio` и `minio-init` сервисы добавлены в `docker-compose.yml`
+- [x] `deploy.yml` создаёт `/mnt/data/alteko/minio` при деплое
+- [x] `.env.example` документирует MinIO credentials
+- [ ] Smoke test: загрузить файл, прочитать обратно (пост-деплой, после установки реальных credentials)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,22 @@ const config = {
   outputFileTracingIncludes: {
     '*': ['./node_modules/next/dist/lib/**/*'],
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), payment=()',
+          },
+        ],
+      },
+    ]
+  },
   webpack(webpackConfig, { webpack }) {
     if (!webpackConfig.resolve) webpackConfig.resolve = {}
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "alteko",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22 <23",
+    "npm": ">=10 <12"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,6 +4,7 @@ import { getMessages, getTranslations } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import { routing } from '@/i18n/routing'
 import { localizedAlternates } from '@/lib/seo'
+import { CookieConsent } from '@/components/cookie-consent'
 import type { Metadata } from 'next'
 
 const SITE_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://alteko.lv'
@@ -66,6 +67,7 @@ export default async function LocaleLayout({ children, params }: Props) {
         <NextIntlClientProvider messages={messages}>
           {children}
         </NextIntlClientProvider>
+        <CookieConsent />
       </body>
     </html>
   )

--- a/src/app/api/address/resolve/route.ts
+++ b/src/app/api/address/resolve/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { env } from '@/env'
 import { prisma } from '@/lib/prisma'
 import { IS_STUB, stubBuildingForAddress } from '@/lib/stubs'
+import { checkRateLimit, getClientIp, rateLimitExceeded } from '@/lib/rate-limit'
 import type { EnergyClass } from '@prisma/client'
 
 export const runtime = 'nodejs'
@@ -36,6 +37,9 @@ async function fetchCadastralCode(lat: number, lon: number): Promise<string | nu
 }
 
 export async function GET(req: NextRequest) {
+  const { allowed } = checkRateLimit(getClientIp(req))
+  if (!allowed) return rateLimitExceeded()
+
   const lat = parseFloat(req.nextUrl.searchParams.get('lat') ?? '')
   const lon = parseFloat(req.nextUrl.searchParams.get('lon') ?? '')
   const address = req.nextUrl.searchParams.get('address') ?? ''

--- a/src/app/api/address/search/route.ts
+++ b/src/app/api/address/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { IS_STUB, STUB_ADDRESS_SUGGESTIONS } from '@/lib/stubs'
+import { checkRateLimit, getClientIp, rateLimitExceeded } from '@/lib/rate-limit'
 
 export const runtime = 'nodejs'
 
@@ -29,6 +30,9 @@ function formatAddress(addr: NominatimAddress): string {
 }
 
 export async function GET(req: NextRequest) {
+  const { allowed } = checkRateLimit(getClientIp(req))
+  if (!allowed) return rateLimitExceeded()
+
   const query = req.nextUrl.searchParams.get('q')?.trim()
   const city = req.nextUrl.searchParams.get('city')?.trim()
   if (!query || query.length < 3) return NextResponse.json([])

--- a/src/app/api/audit/upload/route.ts
+++ b/src/app/api/audit/upload/route.ts
@@ -4,12 +4,16 @@ import { uploadFile, buildReportKey } from '@/lib/s3'
 import { auth } from '@/auth'
 import { IS_STUB } from '@/lib/stubs'
 import { issueParseToken } from '@/lib/auth/parse-token'
+import { checkRateLimit, getClientIp, rateLimitExceeded } from '@/lib/rate-limit'
 
 export const runtime = 'nodejs'
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024
 
 export async function POST(req: NextRequest) {
+  const { allowed } = checkRateLimit(getClientIp(req), 10, 60_000)
+  if (!allowed) return rateLimitExceeded()
+
   const session = await auth()
   // uploadedBy is nullable — anonymous uploads allowed; email gate links later
   const userId = session?.user?.id ?? null

--- a/src/app/api/buildings/[cadastralCode]/documents/route.ts
+++ b/src/app/api/buildings/[cadastralCode]/documents/route.ts
@@ -14,6 +14,7 @@ import {
   deleteFile,
   getPresignedDownloadUrl,
 } from '@/lib/s3'
+import { checkRateLimit, getClientIp, rateLimitExceeded } from '@/lib/rate-limit'
 import { BuildingDocumentType } from '@prisma/client'
 
 export const runtime = 'nodejs'
@@ -61,6 +62,9 @@ async function authorizeBoard() {
 }
 
 export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const { allowed } = checkRateLimit(getClientIp(_req))
+  if (!allowed) return rateLimitExceeded()
+
   const auth = await authorizeBoard()
   if ('error' in auth) return auth.error
 

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+const CONSENT_KEY = 'alteko-cookie-consent'
+
+export function CookieConsent() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!localStorage.getItem(CONSENT_KEY)) {
+      setVisible(true)
+    }
+  }, [])
+
+  function accept() {
+    localStorage.setItem(CONSENT_KEY, 'accepted')
+    setVisible(false)
+  }
+
+  function decline() {
+    localStorage.setItem(CONSENT_KEY, 'necessary-only')
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <div
+      role="region"
+      aria-label="Sīkdatņu piekrišana"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-gray-200 bg-white px-4 py-4 shadow-lg sm:px-6"
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-gray-600">
+          Mēs izmantojam obligātās sīkdatnes, lai nodrošinātu platformas darbību
+          (autentifikācija, sesijas). Neobligātās analītikas sīkdatnes netiek izmantotas.{' '}
+          <a href="/privacy" className="underline hover:text-gray-900">
+            Privātuma politika
+          </a>
+        </p>
+        <div className="flex shrink-0 gap-2">
+          <button
+            onClick={decline}
+            className="rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+          >
+            Tikai nepieciešamās
+          </button>
+          <button
+            onClick={accept}
+            className="rounded bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700"
+          >
+            Piekrist
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+interface Counter {
+  count: number
+  reset: number
+}
+
+// In-memory sliding-window rate limiter.
+// Works for single-container Node.js deployment; not suitable for edge runtime.
+// State is lost on container restart — acceptable since rate limits are soft defenses.
+const store = new Map<string, Counter>()
+
+export function checkRateLimit(
+  ip: string,
+  limit = 60,
+  windowMs = 60_000,
+): { allowed: boolean; remaining: number } {
+  const now = Date.now()
+  const entry = store.get(ip)
+
+  if (!entry || now >= entry.reset) {
+    store.set(ip, { count: 1, reset: now + windowMs })
+    return { allowed: true, remaining: limit - 1 }
+  }
+
+  if (entry.count >= limit) {
+    return { allowed: false, remaining: 0 }
+  }
+
+  entry.count++
+  return { allowed: true, remaining: limit - entry.count }
+}
+
+// Extracts real client IP, respecting X-Forwarded-For from nginx proxy.
+export function getClientIp(req: NextRequest): string {
+  const forwarded = req.headers.get('x-forwarded-for')
+  if (forwarded) return forwarded.split(',')[0].trim()
+  return req.headers.get('x-real-ip') ?? '127.0.0.1'
+}
+
+// Produces a 429 response with standard Retry-After header.
+export function rateLimitExceeded(): NextResponse {
+  return NextResponse.json(
+    { error: 'Too many requests. Please try again later.' },
+    { status: 429, headers: { 'Retry-After': '60' } },
+  )
+}


### PR DESCRIPTION
## Summary

Batch fix of all actionable open issues before public launch of alteko.lv.

### Issue #154 — Post-launch punch list (P1 items)
- **Item 1** ✅ `HOSTNAME=0.0.0.0` added to app service — fixes healthcheck FailingStreak (Next.js standalone was binding on localhost/::1 inside container, wget couldn't connect)
- **Item 4** ✅ SSH-based cron schedule in sync-data.yml (weekly Sun 03:00 UTC, monthly 1st 04:00 UTC) — runs scripts inside VPS container via appleboy/ssh-action
- **Item 5** ✅ GDPR cookie consent banner (LV text, localStorage, necessary-only vs accept-all)
- **Item 7** ✅ Security headers on all routes: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy`
- **Item 8** ✅ In-memory rate limiting on public APIs: 60 req/min/IP on `/api/address/*`, `/api/buildings/*`; 10 req/min/IP on `/api/audit/upload`
- **Item 11** ✅ `engines` field in package.json (`node >=22 <23`, `npm >=10 <12`)
- **Item 12** ✅ Post-deploy smoke tests in deploy.yml (warning-only, checks 5 public URLs)

### Issue #152 — MinIO on Hetzner Volume (supersedes ADR-0001)
- ✅ `minio` + `minio-init` services added to docker-compose.yml
  - Pinned images: `minio/minio:RELEASE.2024-11-07T00-52-20Z`, `minio/mc:RELEASE.2024-11-09T19-22-20Z`
  - Data stored at `/mnt/data/alteko/minio` (Hetzner Volume / Ceph)
  - minio-init creates 4 buckets on first start: documents, uploads, reports, media
  - Internal only: port `127.0.0.1:3021:9000`
- ✅ ADR-0002 created, ADR-0001 marked as superseded
- ✅ deploy.yml: creates minio dir, passes `MINIO_ROOT_USER/PASSWORD` (from S3 credentials)
- ✅ `SENTRY_DSN` env var plumbed through deploy.yml + .env.example (for future Sentry setup)

## Not in scope (requires human action)
- **#122** SIA registration (legal action at ur.gov.lv)
- **#153** Real API keys: OPENAI_API_KEY, RESEND_API_KEY, S3_* (after MinIO setup)
- **#139** Resend domain verify + DKIM/DMARC DNS at nic.lv
- **#154 item 3** Off-site DB backup (Backblaze B2 rclone setup)
- **#154 item 6** Sentry DSN (needs sentry.io account + @sentry/nextjs install)
- **#129** Speciālista portfelis Phase 2 (pre-conditions not met yet)

## Test plan
- [ ] TypeScript: `npx tsc --noEmit` → 0 errors ✅
- [ ] docker-compose.yml: `docker compose config` validates successfully
- [ ] After merge + deploy: `docker compose ps` shows app, db, minio all healthy
- [ ] After merge + deploy: `/api/health` returns 200 consistently (no more FailingStreak)
- [ ] Cookie consent banner visible on first visit, localStorage key set after click
- [ ] Security headers present: `curl -I https://alteko.lv | grep -i x-frame`
- [ ] Rate limit: 61st request to `/api/address/search` within 60s → 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)